### PR TITLE
Fixing erroneous packets from causing the dedicated servers to crash

### DIFF
--- a/BeatTogether.LiteNetLib/BeatTogether.LiteNetLib.csproj
+++ b/BeatTogether.LiteNetLib/BeatTogether.LiteNetLib.csproj
@@ -5,7 +5,7 @@
 		<Authors>Goobwabber</Authors>
 		<Company>Goobwabber</Company>
 		<RepositoryUrl>https://github.com/Goobwabber/BeatTogether.LiteNetLib</RepositoryUrl>
-		<Version>0.3.12</Version>
+		<Version>0.3.13</Version>
 		<Nullable>enable</Nullable>
 		<TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     </PropertyGroup>

--- a/BeatTogether.LiteNetLib/Handlers/MergedPacketHandler.cs
+++ b/BeatTogether.LiteNetLib/Handlers/MergedPacketHandler.cs
@@ -1,6 +1,7 @@
 ﻿using BeatTogether.LiteNetLib.Abstractions;
 using BeatTogether.LiteNetLib.Headers;
 using Krypton.Buffers;
+using System;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -20,8 +21,13 @@ namespace BeatTogether.LiteNetLib.Handlers
         {
             while (reader.RemainingSize > 0)
             {
-                ushort size = reader.ReadUInt16();
-                var newPacket = reader.ReadBytes(size);
+                ReadOnlySpan<byte> newPacket;
+                try
+                {
+                    ushort size = reader.ReadUInt16();
+                    newPacket = reader.ReadBytes(size);
+                }
+                catch(EndOfBufferException) { return Task.CompletedTask; }
                 _server.HandlePacket(endPoint, newPacket);
             }
             return Task.CompletedTask;

--- a/BeatTogether.LiteNetLib/Headers/ConnectRequestHeader.cs
+++ b/BeatTogether.LiteNetLib/Headers/ConnectRequestHeader.cs
@@ -13,11 +13,11 @@ namespace BeatTogether.LiteNetLib.Headers
 
         public override void ReadFrom(ref SpanBufferReader bufferReader)
         {
-                base.ReadFrom(ref bufferReader);            //1
-                ProtocolId = bufferReader.ReadInt32();      //4
-                ConnectionTime = bufferReader.ReadInt64();  //8
-                int addressSize = bufferReader.ReadByte();  //1 = 14 bytes
-                Address = bufferReader.ReadBytes(addressSize).ToArray(); //and misreads this 
+            base.ReadFrom(ref bufferReader);
+            ProtocolId = bufferReader.ReadInt32();
+            ConnectionTime = bufferReader.ReadInt64();
+            int addressSize = bufferReader.ReadByte();
+            Address = bufferReader.ReadBytes(addressSize).ToArray();
         }
 
         public override void WriteTo(ref SpanBufferWriter bufferWriter)

--- a/BeatTogether.LiteNetLib/Headers/ConnectRequestHeader.cs
+++ b/BeatTogether.LiteNetLib/Headers/ConnectRequestHeader.cs
@@ -13,11 +13,11 @@ namespace BeatTogether.LiteNetLib.Headers
 
         public override void ReadFrom(ref SpanBufferReader bufferReader)
         {
-            base.ReadFrom(ref bufferReader);
-            ProtocolId = bufferReader.ReadInt32();
-            ConnectionTime = bufferReader.ReadInt64();
-            int addressSize = bufferReader.ReadByte();
-            Address = bufferReader.ReadBytes(addressSize).ToArray();
+                base.ReadFrom(ref bufferReader);            //1
+                ProtocolId = bufferReader.ReadInt32();      //4
+                ConnectionTime = bufferReader.ReadInt64();  //8
+                int addressSize = bufferReader.ReadByte();  //1 = 14 bytes
+                Address = bufferReader.ReadBytes(addressSize).ToArray(); //and misreads this 
         }
 
         public override void WriteTo(ref SpanBufferWriter bufferWriter)

--- a/BeatTogether.LiteNetLib/LiteNetServer.cs
+++ b/BeatTogether.LiteNetLib/LiteNetServer.cs
@@ -65,7 +65,11 @@ namespace BeatTogether.LiteNetLib
                 PacketProperty property = (PacketProperty)(buffer[0] & 0x1f); // 0x1f 00011111
                 if (!_packetRegistry.TryCreatePacket(property, out var packet))
                     return;
-                packet.ReadFrom(ref bufferReader);
+                try
+                {
+                    packet.ReadFrom(ref bufferReader);
+                }
+                catch (EndOfBufferException) { return; } //Will ignore erranous packets that have incorrect data
                 var packetHandlerType = typeof(IPacketHandler<>)
                         .MakeGenericType(packet.GetType());
                 var packetHandler = _serviceProvider.GetService(packetHandlerType);


### PR DESCRIPTION
handled span buffer reader exceptions that can be caused by sending a packet with incorrect data or an erroneous packet in general