### PR TITLE
Drastically improved performance , now several times faster than official lnl

### DIFF
--- a/BeatTogether.LiteNetLib/BeatTogether.LiteNetLib.csproj
+++ b/BeatTogether.LiteNetLib/BeatTogether.LiteNetLib.csproj
@@ -5,7 +5,7 @@
 		<Authors>Goobwabber</Authors>
 		<Company>Goobwabber</Company>
 		<RepositoryUrl>https://github.com/Goobwabber/BeatTogether.LiteNetLib</RepositoryUrl>
-		<Version>0.6.2</Version>
+		<Version>0.6.4</Version>
 		<Nullable>enable</Nullable>
 		<TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     </PropertyGroup>

--- a/BeatTogether.LiteNetLib/Dispatchers/ConnectedMessageDispatcher.cs
+++ b/BeatTogether.LiteNetLib/Dispatchers/ConnectedMessageDispatcher.cs
@@ -40,7 +40,6 @@ namespace BeatTogether.LiteNetLib.Dispatchers
             if (method == DeliveryMethod.Sequenced)
             {
                 GetWindow(endPoint, channelId, out var window);
-                //_ = window.Enqueue(out int queueIndex);
                 window.Enqueue(out int queueIndex);
 
                 return SendChanneled(endPoint, message, channelId, queueIndex);
@@ -84,11 +83,7 @@ namespace BeatTogether.LiteNetLib.Dispatchers
 
         private async Task SendAndRetry(EndPoint endPoint, MemoryBuffer message, byte channelId, bool fragmented = false, ushort fragmentId = 0, ushort fragmentPart = 0, ushort fragmentsTotal = 0)
         {
-            //var window = _channelWindows.GetOrAdd(endPoint, _ => new())
-            //    .GetOrAdd(channelId, _ => new(_configuration.WindowSize, _configuration.MaxSequence));
-            //await window.Enqueue(out int queueIndex);
             GetWindow(endPoint, channelId, out var window);
-            //await window.Enqueue(out int queueIndex);
             window.Enqueue(out int queueIndex);
 
             int OldOffset = message.Offset;

--- a/BeatTogether.LiteNetLib/Models/FragmentBuilder.cs
+++ b/BeatTogether.LiteNetLib/Models/FragmentBuilder.cs
@@ -1,9 +1,6 @@
 ﻿using BeatTogether.LiteNetLib.Util;
-using Krypton.Buffers;
 using System;
-using System.Buffers;
-using System.Collections.Concurrent;
-using System.Threading;
+using System.Collections.Generic;
 
 namespace BeatTogether.LiteNetLib.Models
 {
@@ -13,7 +10,7 @@ namespace BeatTogether.LiteNetLib.Models
         private int _fragmentsReceived;
 
         private readonly int _totalFragments;
-        private readonly ConcurrentDictionary<int, ReadOnlyMemory<byte>> _fragments = new();
+        private readonly Dictionary<int, ReadOnlyMemory<byte>> _fragments = new();
 
         public FragmentBuilder(int totalFragments)
         {
@@ -24,6 +21,8 @@ namespace BeatTogether.LiteNetLib.Models
         {
             lock (_fragmentsLock)
             {
+                if(_fragmentsReceived >= _totalFragments)
+                    return false;
                 if (_fragments.TryAdd(fragmentId, new ReadOnlyMemory<byte>(buffer.ToArray())))
                         _fragmentsReceived++;
                 return _fragmentsReceived >= _totalFragments;

--- a/BeatTogether.LiteNetLib/Models/QueueWindow.cs
+++ b/BeatTogether.LiteNetLib/Models/QueueWindow.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace BeatTogether.LiteNetLib.Models
@@ -8,8 +11,11 @@ namespace BeatTogether.LiteNetLib.Models
     /// </summary>
     public class QueueWindow
     {
-        private readonly ConcurrentDictionary<int, TaskCompletionSource> _taskQueue = new();
-        private readonly ConcurrentDictionary<int, TaskCompletionSource> _dequeueTasks = new();
+        //private readonly Dictionary<int, TaskCompletionSource> _taskQueue = new();
+        private readonly HashSet<int> _queue = new HashSet<int>();
+        private readonly object _taskQueueLock = new();
+        private readonly Dictionary<int, TaskCompletionSource> _dequeueTasks = new();
+        private readonly object _taskDeQueueLock = new();
         private readonly int _queueSize;
         private readonly int _windowSize;
         private object _windowPositionLock = new();
@@ -29,7 +35,15 @@ namespace BeatTogether.LiteNetLib.Models
 
             // Complete tasks inside window
             for (int i = 0; i < windowSize; i++)
-                _taskQueue.GetOrAdd(i, _ => new()).SetResult();
+            {
+                TaskCompletionSource task = new();
+                task.SetResult();
+                //_taskQueue.Add(i, task);
+                lock (_taskQueueLock)
+                {
+                    _queue.Add(i);
+                }
+            }
         }
 
         /// <summary>
@@ -37,14 +51,15 @@ namespace BeatTogether.LiteNetLib.Models
         /// </summary>
         /// <param name="index">Index task was queued at</param>
         /// <returns>Queued task</returns>
-        public Task Enqueue(out int index)
+        public void Enqueue(out int index)
         {
             lock (_queuePositionLock)
             {
                 _queuePosition = (_queuePosition + 1) % _queueSize;
                 index = _queuePosition;
             }
-            return EnqueueAtIndex(index);
+            //return EnqueueAtIndex(index);
+            EnqueueAtIndex(index);
         }
 
         /// <summary>
@@ -52,8 +67,26 @@ namespace BeatTogether.LiteNetLib.Models
         /// </summary>
         /// <param name="index">Index to queue task at</param>
         /// <returns>Queued task</returns>
+        /*
         public Task EnqueueAtIndex(int index)
-            => _taskQueue.GetOrAdd(index, _ => new()).Task;
+        {
+            lock (_taskQueueLock)
+            {
+                if (!_taskQueue.TryGetValue(index, out var task))
+                {
+                    _taskQueue.Add(index, task = new());
+                    task.SetResult();
+                }
+                return task.Task;
+            }
+        }*/
+        public void EnqueueAtIndex(int index)
+        {
+            lock (_taskQueueLock)
+            {
+                _queue.Add(index);
+            }
+        }
 
         /// <summary>
         /// Provides a task that will be completed when the task at an index is dequeued.
@@ -62,9 +95,19 @@ namespace BeatTogether.LiteNetLib.Models
         /// <returns>Task that is completed on dequeue</returns>
         public Task WaitForDequeue(int index)
         {
-            if ((index - _windowPosition + _queueSize + _queueSize / 2) % _queueSize - _queueSize / 2 < 0)
-                return Task.CompletedTask;
-            return _dequeueTasks.GetOrAdd(index, _ => new()).Task;
+            lock (_windowPositionLock)
+            {
+                if ((index - _windowPosition + _queueSize + _queueSize / 2) % _queueSize - _queueSize / 2 < 0)
+                    return Task.CompletedTask;
+            }
+            lock (_taskDeQueueLock)
+            {
+                if (!_dequeueTasks.TryGetValue(index, out var task))
+                {
+                    _dequeueTasks.Add(index, task = new());
+                }
+                return task.Task;
+            }
         }
 
         /// <summary>
@@ -74,9 +117,17 @@ namespace BeatTogether.LiteNetLib.Models
         /// <returns>Whether task was successfully dequeued</returns>
         public bool Dequeue(int index)
         {
-            bool dequeued = _taskQueue.TryRemove(index, out _);
-            if (_dequeueTasks.TryRemove(index, out var dequeueTask))
-                dequeueTask.SetResult();
+            bool dequeued;
+            lock (_taskQueueLock)
+            {
+                //dequeued = _taskQueue.Remove(index, out var task);
+                dequeued = _queue.Remove(index);
+            }
+            lock (_taskDeQueueLock)
+            {
+                if (_dequeueTasks.Remove(index, out var dequeueTask))
+                    dequeueTask.SetResult();
+            }
             Advance();
             return dequeued;
         }
@@ -87,7 +138,13 @@ namespace BeatTogether.LiteNetLib.Models
         /// <param name="index">The index to check at</param>
         /// <returns>Whether a task is queued at index</returns>
         public bool IsIndexQueued(int index)
-            => _taskQueue.ContainsKey(index);
+        {
+            lock (_taskQueueLock)
+            {
+                //return _taskQueue.ContainsKey(index);
+                return _queue.Contains(index);
+            }
+        }
 
         /// <summary>
         /// Advances the window to the next available index in the queue.
@@ -96,16 +153,25 @@ namespace BeatTogether.LiteNetLib.Models
         {
             lock (_windowPositionLock)
             {
-                if (_taskQueue.ContainsKey(_windowPosition))
+                if (IsIndexQueued(_windowPosition))
                     return; // Should not advance
                 _windowPosition = (_windowPosition + 1) % _queueSize;
 
                 // Complete tasks that have entered the window
                 var newestIndex = (_windowPosition + _windowSize - 1) % _queueSize;
-                _taskQueue.GetOrAdd(newestIndex, _ => new()).SetResult();
-
+                lock (_taskQueueLock)
+                {
+                    _queue.Add(newestIndex);
+                    /*
+                    if (!_taskQueue.TryGetValue(newestIndex, out var task))
+                    {
+                        _taskQueue.Add(newestIndex, task = new());
+                    }
+                    task.SetResult();
+                    */
+                }
                 // Advance window again if current index has been handled
-                if (!_taskQueue.ContainsKey(_windowPosition))
+                if (!IsIndexQueued(_windowPosition))
                     Advance();
             }
         }

--- a/BeatTogether.LiteNetLib/Models/QueueWindow.cs
+++ b/BeatTogether.LiteNetLib/Models/QueueWindow.cs
@@ -38,7 +38,6 @@ namespace BeatTogether.LiteNetLib.Models
             {
                 TaskCompletionSource task = new();
                 task.SetResult();
-                //_taskQueue.Add(i, task);
                 lock (_taskQueueLock)
                 {
                     _queue.Add(i);
@@ -50,7 +49,6 @@ namespace BeatTogether.LiteNetLib.Models
         /// Enqueues a task at the next available index.
         /// </summary>
         /// <param name="index">Index task was queued at</param>
-        /// <returns>Queued task</returns>
         public void Enqueue(out int index)
         {
             lock (_queuePositionLock)
@@ -66,20 +64,6 @@ namespace BeatTogether.LiteNetLib.Models
         /// Enqueues a task at a specified index.
         /// </summary>
         /// <param name="index">Index to queue task at</param>
-        /// <returns>Queued task</returns>
-        /*
-        public Task EnqueueAtIndex(int index)
-        {
-            lock (_taskQueueLock)
-            {
-                if (!_taskQueue.TryGetValue(index, out var task))
-                {
-                    _taskQueue.Add(index, task = new());
-                    task.SetResult();
-                }
-                return task.Task;
-            }
-        }*/
         public void EnqueueAtIndex(int index)
         {
             lock (_taskQueueLock)
@@ -120,7 +104,6 @@ namespace BeatTogether.LiteNetLib.Models
             bool dequeued;
             lock (_taskQueueLock)
             {
-                //dequeued = _taskQueue.Remove(index, out var task);
                 dequeued = _queue.Remove(index);
             }
             lock (_taskDeQueueLock)
@@ -141,7 +124,6 @@ namespace BeatTogether.LiteNetLib.Models
         {
             lock (_taskQueueLock)
             {
-                //return _taskQueue.ContainsKey(index);
                 return _queue.Contains(index);
             }
         }
@@ -162,13 +144,6 @@ namespace BeatTogether.LiteNetLib.Models
                 lock (_taskQueueLock)
                 {
                     _queue.Add(newestIndex);
-                    /*
-                    if (!_taskQueue.TryGetValue(newestIndex, out var task))
-                    {
-                        _taskQueue.Add(newestIndex, task = new());
-                    }
-                    task.SetResult();
-                    */
                 }
                 // Advance window again if current index has been handled
                 if (!IsIndexQueued(_windowPosition))

--- a/BeatTogether.LiteNetLib/Sources/ConnectedMessageSource.cs
+++ b/BeatTogether.LiteNetLib/Sources/ConnectedMessageSource.cs
@@ -3,17 +3,18 @@ using BeatTogether.LiteNetLib.Enums;
 using BeatTogether.LiteNetLib.Headers;
 using BeatTogether.LiteNetLib.Models;
 using BeatTogether.LiteNetLib.Util;
-using Krypton.Buffers;
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Net;
 
 namespace BeatTogether.LiteNetLib.Sources
 {
     public abstract class ConnectedMessageSource : IDisposable
     {
-        private readonly ConcurrentDictionary<EndPoint, ConcurrentDictionary<ushort, FragmentBuilder>> _fragmentBuilders = new();
-        private readonly ConcurrentDictionary<EndPoint, ConcurrentDictionary<byte, AckWindow>> _channelWindows = new();
+        private readonly Dictionary<EndPoint, (object, Dictionary<ushort, FragmentBuilder>)> _fragmentBuilders = new();
+        private readonly object _fragmentLock = new();
+        private readonly Dictionary<EndPoint, (object, Dictionary<byte, AckWindow>)> _channelWindows = new();
+        private readonly object _channelWindowLock = new();
         private readonly LiteNetConfiguration _configuration;
         private readonly LiteNetServer _server;
 
@@ -31,15 +32,51 @@ namespace BeatTogether.LiteNetLib.Sources
             => _server.ClientDisconnectEvent -= HandleDisconnect;
 
         public void HandleDisconnect(EndPoint endPoint, DisconnectReason reason)
-            => _channelWindows.TryRemove(endPoint, out _);
+        {
+            lock(_channelWindowLock){
+                _channelWindows.Remove(endPoint, out _);
+            }
+            lock(_fragmentLock){
+                _fragmentBuilders.Remove(endPoint, out _);
+            }
+        }
 
         public virtual void Signal(EndPoint remoteEndPoint, UnreliableHeader header, ref SpanBuffer reader)
             => OnReceive(remoteEndPoint, ref reader, DeliveryMethod.Unreliable);
 
+
+        private void GetWindow(EndPoint endPoint, byte channelId, out AckWindow window)
+        {
+            (object, Dictionary<byte, AckWindow>) windows;
+            lock (_channelWindowLock)
+            {
+                if (!_channelWindows.TryGetValue(endPoint, out windows))
+                    _channelWindows.Add(endPoint, windows = (new(), new()));
+            }
+            lock (windows.Item1)
+            {
+                if (!windows.Item2.TryGetValue(channelId, out window!))
+                    windows.Item2.Add(channelId, window = new(_configuration.WindowSize, _configuration.MaxSequence));
+            }
+        }
+        private void GetFragmentBuilder(EndPoint endPoint, ushort FragmentId, ushort TotalFragments, out FragmentBuilder Builder)
+        {
+            (object, Dictionary<ushort, FragmentBuilder>) Builders;
+            lock (_fragmentLock)
+            {
+                if (!_fragmentBuilders.TryGetValue(endPoint, out Builders))
+                    _fragmentBuilders.Add(endPoint, Builders = (new(), new()));
+            }
+            lock (Builders.Item1)
+            {
+                if (!Builders.Item2.TryGetValue(FragmentId, out Builder!))
+                    Builders.Item2.Add(FragmentId, Builder = new(TotalFragments));
+            }
+        }
+
         public virtual void Signal(EndPoint remoteEndPoint, ChanneledHeader header, ref SpanBuffer reader)
         {
-            var window = _channelWindows.GetOrAdd(remoteEndPoint, _ => new())
-                .GetOrAdd(header.ChannelId, _ => new(_configuration.WindowSize, _configuration.MaxSequence));
+            GetWindow(remoteEndPoint, header.ChannelId, out var window);
             var alreadyReceived = !window.Add(header.Sequence);
             var windowArray = window.GetWindow(out int windowPosition);
 
@@ -53,8 +90,7 @@ namespace BeatTogether.LiteNetLib.Sources
 
             if (header.IsFragmented)
             {
-                var builder = _fragmentBuilders.GetOrAdd(remoteEndPoint, _ => new())
-                    .GetOrAdd(header.FragmentId, _ => new(header.FragmentsTotal));
+                GetFragmentBuilder(remoteEndPoint, header.FragmentId, header.FragmentsTotal, out var builder);
 
                 if (builder.AddFragment(header.FragmentPart, reader.RemainingData))
                 {


### PR DESCRIPTION
Removed concurrent dictionaries in favour of locks
Removed seemingly un-used task that was awaited for queue windows (may be needed, but tested with 20 bots in mp lobby and no issues)